### PR TITLE
Add format-selection command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ Format SQL files using the [sql-formatter-plus](https://github.com/kufii/sql-for
 **`sql-formatter.uppercase`**: Convert keywords to uppercase. Defaults to false.
 
 **`sql-formatter.linesBetweenQueries`**: Number of linebreaks between queries. Defaults to 2.
+
+## Commands
+The following command is also added to VS Code:
+
+`vscode-sql-formatter.format-selection (Format the selected SQL using the configured settings)`
+- Formats the selected text based on the current settings, regardless of the editor's Language Mode.

--- a/package.json
+++ b/package.json
@@ -22,9 +22,16 @@
     "pl/sql"
   ],
   "activationEvents": [
-    "onLanguage:sql"
+    "onLanguage:sql",
+    "onCommand:vscode-sql-formatter.format-selection"
   ],
   "contributes": {
+    "commands": [
+      {
+        "command": "vscode-sql-formatter.format-selection",
+        "title": "SQL Formatter: Format the selected SQL using the configured settings"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "SQL Formatter",

--- a/src/extension.js
+++ b/src/extension.js
@@ -21,11 +21,33 @@ const getConfig = ({ insertSpaces, tabSize }) => ({
 	linesBetweenQueries: getSetting('sql-formatter', 'linesBetweenQueries', 2)
 });
 
+const formatSelection = () => {
+	const editor = vscode.window.activeTextEditor;
+
+	if (editor) {
+		const document = editor.document;
+		const selection = editor.selection;
+		const text = document.getText(selection);
+
+		if(text) {
+			const formatted = format(text);
+			editor.edit(editBuilder => {
+				editBuilder.replace(selection, formatted);
+			});
+		}
+	}
+};
+
 const format = (text, config) => sqlFormatter.format(text, config);
 
-module.exports.activate = () =>
+module.exports.activate = (context) => {
+	const formatSelectionCommand = vscode.commands.registerCommand('vscode-sql-formatter.format-selection', formatSelection);
+	
 	vscode.languages.registerDocumentRangeFormattingEditProvider('sql', {
 		provideDocumentRangeFormattingEdits: (document, range, options) => [
 			vscode.TextEdit.replace(range, format(document.getText(range), getConfig(options)))
 		]
 	});
+
+	context.subscriptions.push(formatSelectionCommand);
+}

--- a/src/extension.js
+++ b/src/extension.js
@@ -28,9 +28,13 @@ const formatSelection = () => {
 		const document = editor.document;
 		const selection = editor.selection;
 		const text = document.getText(selection);
+		const options = {
+			insertSpaces: editor.insertSpaces,
+			tabSize: editor.tabSize,
+		};
 
 		if(text) {
-			const formatted = format(text);
+			const formatted = format(text, getConfig(options));
 			editor.edit(editBuilder => {
 				editBuilder.replace(selection, formatted);
 			});


### PR DESCRIPTION
Registers a new command with VS Code, `format-selection`, which can be used to format text as SQL even when the Language Mode is not explicitly set to `SQL`. Uses the same configuration settings as the existing functionality.