### PR TITLE
Added Oracle SQL Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "formatter",
     "n1ql",
     "db2",
-    "pl/sql"
+    "pl/sql",
+    "oraclesql"
   ],
   "activationEvents": [
     "onLanguage:sql"

--- a/src/extension.js
+++ b/src/extension.js
@@ -29,3 +29,10 @@ module.exports.activate = () =>
 			vscode.TextEdit.replace(range, format(document.getText(range), getConfig(options)))
 		]
 	});
+
+module.exports.activate = () =>
+	vscode.languages.registerDocumentRangeFormattingEditProvider('oraclesql', {
+		provideDocumentRangeFormattingEdits: (document, range, options) => [
+			vscode.TextEdit.replace(range, format(document.getText(range), getConfig(options)))
+		]
+	});


### PR DESCRIPTION
Added a support for the 'oraclesql' file type in VS Code. This is what VS Code associates .sql file types with when using Oracle Dev Tools in VS Code; despite being SQL files, VS Code considers them to be 'oraclesql' instead and the formatter did not work initially.

Also added a keyword for it in the package.json.